### PR TITLE
Always respond with endpoints when a cluster is warming

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,6 +110,8 @@ type watches struct {
 	listenerNonce string
 	secretNonce   string
 	runtimeNonce  string
+
+	endpointNonceAcked bool
 }
 
 // Cancel all watches
@@ -217,6 +219,31 @@ func (s *server) process(stream stream, reqCh <-chan *v2.DiscoveryRequest, defau
 	// node may only be set on the first discovery request
 	var node = &core.Node{}
 
+	peekResponse := func(req cache.Request) *cache.Response {
+		versionInfo := req.VersionInfo
+		req.VersionInfo = "" // trick cache into returning a response despite unchanged version
+		resp, err := s.cache.Fetch(stream.Context(), req)
+		if err != nil || resp == nil {
+			return nil
+		}
+		resp.Request.VersionInfo = versionInfo // restore the original value
+		return resp
+	}
+	scheduleResponse := func(resp cache.Response) (value chan cache.Response, cancel func()) {
+		value = make(chan cache.Response, 1)
+		value <- resp
+		cancel = func() {
+			close(value)
+
+			// consume channel
+			select {
+			case <-value:
+			default:
+			}
+		}
+		return
+	}
+
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -231,6 +258,7 @@ func (s *server) process(stream stream, reqCh <-chan *v2.DiscoveryRequest, defau
 				return err
 			}
 			values.endpointNonce = nonce
+			values.endpointNonceAcked = false
 
 		case resp, more := <-values.clusters:
 			if !more {
@@ -319,10 +347,22 @@ func (s *server) process(stream stream, reqCh <-chan *v2.DiscoveryRequest, defau
 			// cancel existing watches to (re-)request a newer version
 			switch {
 			case req.TypeUrl == cache.EndpointType && (values.endpointNonce == "" || values.endpointNonce == nonce):
+				// If Envoy uses the same Nonce for the second time, it probably means that
+				// a Cluster has been created or updated and goes through the warming stage.
+				// In that case we must respond even if EDS configuration hasn't changed.
+				var resp *cache.Response
+				if values.endpointNonceAcked {
+					resp = peekResponse(*req)
+				}
+				values.endpointNonceAcked = values.endpointNonce != "" && values.endpointNonce == nonce
 				if values.endpointCancel != nil {
 					values.endpointCancel()
 				}
-				values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
+				if resp != nil {
+					values.endpoints, values.endpointCancel = scheduleResponse(*resp)
+				} else {
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
+				}
 			case req.TypeUrl == cache.ClusterType && (values.clusterNonce == "" || values.clusterNonce == nonce):
 				if values.clusterCancel != nil {
 					values.clusterCancel()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -537,3 +537,74 @@ func TestCallbackError(t *testing.T) {
 		})
 	}
 }
+
+type hasher struct {}
+
+func (h hasher) ID(node *core.Node) string {
+	if node == nil {
+		return "unknown"
+	}
+	return node.Id
+}
+
+func TestClusterWarming(t *testing.T) {
+	config := cache.NewSnapshotCache(true, hasher{}, nil)
+	config.SetSnapshot(node.Id, cache.NewSnapshot("1", []cache.Resource{endpoint}, nil, nil, nil, nil))
+	resp := makeMockStream(t)
+
+	s := server.NewServer(context.Background(), config, &callbacks{})
+	go func() {
+		if err := s.StreamAggregatedResources(resp); err != nil {
+			t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
+		}
+	}()
+
+	// simulate initial EDS request
+
+	resp.recv <- &v2.DiscoveryRequest{
+		Node:          node,
+		TypeUrl:       cache.EndpointType,
+		ResourceNames: []string{clusterName},
+	}
+
+	var resp1 *v2.DiscoveryResponse
+resp1:
+	for {
+		select {
+		case resp := <-resp.sent:
+			if resp.TypeUrl != cache.EndpointType {
+				t.Errorf("TypeUrl => got %v, want %v", resp.TypeUrl, cache.EndpointType)
+			}
+			resp1 = resp
+			break resp1
+		case <-time.After(1 * time.Second):
+			t.Fatalf("got %d messages on the stream, not 1", 0)
+		}
+	}
+
+	// simulate EDS request as part of cluster warming
+
+	req2 := &v2.DiscoveryRequest{
+		VersionInfo:   resp1.VersionInfo,
+		ResponseNonce: resp1.Nonce,
+		Node:          node,
+		TypeUrl:       cache.EndpointType,
+		ResourceNames: []string{clusterName},
+	}
+
+	resp.recv <- req2 // ACK to resp1
+	resp.recv <- req2 // cluster warming
+
+resp2:
+	for {
+		select {
+		case resp := <-resp.sent:
+			if resp.TypeUrl != cache.EndpointType {
+				t.Errorf("TypeUrl => got %v, want %v", resp.TypeUrl, cache.EndpointType)
+			}
+			break resp2
+		case <-time.After(1 * time.Second):
+			t.Fatalf("got %d messages on the stream, not 1", 0)
+		}
+	}
+}


### PR DESCRIPTION
When a cluster is warming, we will receive an endpoint request. If
endpoints haven't changed recently, then this request will look stale,
and currently we would just leave the watch open. Instead, it is
paramount that we respond immediately, otherwise the cluster will get
no endpoints.

This code is copied verbatim from https://github.com/Kong/kuma/pull/331.
Thanks to @yskopets.